### PR TITLE
Filters::stripTags() allowed tags parameter support

### DIFF
--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -212,14 +212,15 @@ class Filters
 	 * Removes tags from HTML (but remains HTML entites).
 	 * @param
 	 * @param  string HTML
+	 * @param  string tags which should not be stripped
 	 * @return string HTML
 	 */
-	public static function stripTags(FilterInfo $info, $s): string
+	public static function stripTags(FilterInfo $info, $s, $allowableTags = null): string
 	{
 		if (!in_array($info->contentType, [NULL, 'html', 'xhtml', 'htmlAttr', 'xhtmlAttr', 'xml', 'xmlAttr'], TRUE)) {
 			trigger_error("Filter |stripTags used with incompatible type " . strtoupper($info->contentType), E_USER_WARNING);
 		}
-		return strip_tags((string) $s);
+		return strip_tags((string) $s, $allowableTags);
 	}
 
 

--- a/tests/Latte/Filters.stripTags().phpt
+++ b/tests/Latte/Filters.stripTags().phpt
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Test: Latte\Runtime\Filters::stripTags()
+ */
+
+declare(strict_types=1);
+
+use Latte\Engine;
+use Latte\Runtime\Filters;
+use Latte\Runtime\FilterInfo;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test(function () {
+	$info = new FilterInfo(Engine::CONTENT_HTML);
+	Assert::same('',  Filters::stripTags($info, ''));
+	Assert::same('abc',  Filters::stripTags($info, 'abc'));
+	Assert::same('Test paragraph. Other text',  Filters::stripTags($info, '<p>Test paragraph.</p><!-- Comment --> <a href="#fragment">Other text</a>'));
+	Assert::same('<p>Test paragraph.</p> <a href="#fragment">Other text</a>',  Filters::stripTags($info, '<p>Test paragraph.</p><!-- Comment --> <a href="#fragment">Other text</a>', '<p><a>'));
+});
+
+
+test(function () {
+	$info = new FilterInfo(Engine::CONTENT_XHTML);
+	Assert::same('',  Filters::stripTags($info, ''));
+	Assert::same('abc',  Filters::stripTags($info, 'abc'));
+	Assert::same('Test paragraph. Other text',  Filters::stripTags($info, '<p>Test paragraph.</p><!-- Comment --> <a href="#fragment">Other text</a>'));
+	Assert::same('<p>Test paragraph.</p> <a href="#fragment">Other text</a>',  Filters::stripTags($info, '<p>Test paragraph.</p><!-- Comment --> <a href="#fragment">Other text</a>', '<p><a>'));
+});


### PR DESCRIPTION
The second parameter (`$allowable_tags`) of the `strip_tags` php function recall is not supported since a4bb7fe209a843d94bb6ddb60c995f11c819bdd2.

The support is not dropped from the PHP itself so it should remain in the filter too.